### PR TITLE
Update install-houdini-apprentice-license-action action version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           client_id: ${{ secrets.SESI_CLIENT_ID }}
           client_secret_key: ${{ secrets.SESI_SECRET_KEY }}
-          houdini_version: "19.5"
+          houdini_version: 19.5
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Update the install-houdini-apprentice-license-action version to the latest to fix an error occuring during attempts to install licenses while testing.