### PR TITLE
feat: Use ruff for linting and formatting instead of black, flake8 and pylint

### DIFF
--- a/docs/fixtures/hip_file.rst
+++ b/docs/fixtures/hip_file.rst
@@ -15,7 +15,7 @@ load_module_test_hip_file
 -------------------------
 
 The ``load_module_test_hip_file`` fixture will load a test hip file with the same name as the running module.  It
-supports .hip, .hiplc, and .hipnc type files (in that order). The hip file must be under a **data/** directory which is
+supports .hip, .hiplc, and .hipnc file types (in that order). The hip file must be under a **data/** directory which is
 a sibling of the test file. For this package, looking at the tests for the fixtures, we can see that we have a matching
 hip file for ``test_nodes.py`` (``test_nodes.hiplc``).
 
@@ -36,19 +36,19 @@ hip file for ``test_nodes.py`` (``test_nodes.hiplc``).
 
 The fixture will also clear the hip file after the tests are completed.
 
-As this is a **module** level fixture, to use it ensure you've added the following at the top of the test file:
+As this is a **module** level fixture, to use it, ensure you've added the following at the top of the test file:
 
 .. code-block:: python
 
     pytestmark = pytest.mark.usefixtures("load_module_test_hip_file")
 
 
-In the event the fixture cannot find a matching file, the raised ``RuntimeError`` will contain a list of all the paths
-which were tried:
+In the event the fixture cannot find a matching file, the raised ``NoModuleTestFileError`` will contain a list of all
+the paths which were tried:
 
 .. code-block:: python
 
-    RuntimeError: Could not find a valid test hip: {test_file_dir}/data/{test_file_name}{.hip,.hiplc,.hipnc}
+    NoModuleTestFileError: Could not find a valid test hip: {test_file_dir}/data/{test_file_name}{.hip,.hiplc,.hipnc}
 
 
 set_test_frame

--- a/docs/fixtures/nodes.rst
+++ b/docs/fixtures/nodes.rst
@@ -2,12 +2,57 @@
 Nodes
 =====
 
+create_temp_node
+----------------
+
+The ``create_temp_node`` fixture can be used to create temporary testing nodes and not have to worry about
+destroying them after the test is over. Additionally, it can be called multiple times to create many temporary nodes.
+
+It supports a limited number of parameters to affect the node creation:
+
+.. code-block:: python
+
+    def _create(
+        parent: hou.Node,
+        node_type_name: str,
+        node_name: str | None = None,
+        *, run_init_scripts: bool = True
+    ) -> hou.Node:
+        """Function to create a test node that will be destroyed on cleanup.
+
+        Args:
+            parent: The parent to create the test node under.
+            node_type_name: The node type to create.
+            node_name: Optional node name.
+            run_init_scripts: Whether to run the node initialization scripts.
+
+        Return:
+            The created test node.
+        """
+
+In the following example we create some temp nodes to test with.
+
+.. code-block:: python
+
+    def test_some_func(create_temp_node):
+        node1 = create_temp_node(hou.node("/obj"), "geo", "TEST_NODE1", run_init_scripts=False)
+        node2 = create_temp_node(hou.node("/obj"), "null", "TEST_NODE2")
+
+        ... # do testing
+
+After the test function is executed, the created nodes will both be destroyed.  If the test code itself
+destroys a node, the ``hou.ObjectWasDeleted`` exception will be suppressed.
+
+
+Existing Test Node Fixtures
+---------------------------
+
 There are a number of convenience functions which can be used to automatically find test related nodes in the current
 hip file based on the test name data.
 
 The underlying tooling will inspect the ``pytest.FixtureRequest`` object and construct a number of acceptable
 node names/paths for the specific test and try to return one of those.  If a matching node cannot be found a
-``RuntimeError`` is raised and the test will fail.
+``NoTestNodeError`` is raised and the test will fail.
 
 The node search order is as follows:
     - Node matching the exact test name
@@ -45,25 +90,36 @@ the possible nodes found (and their order of precedence) is as follows:
     - /obj/TestMyFunc
     - /obj/testmyfunc
 
-In the event that no valid nodes could be provided, the raised ``RuntimeError`` will contain a list of all paths which
+In the event that no valid nodes could be provided, the raised ``NoTestNodeError`` will contain a list of all paths which
 were tried:
 
 .. code-block:: python
 
-    RuntimeError: Could not find any matching test nodes: /obj/test_none_args, /obj/TestMyFunc_none_args, /obj/testmyfunc_none_args, /obj/TestMyFunc/none_args, /obj/testmyfunc/none_args, /obj/TestMyFunc, /obj/testmyfunc
+    NoTestNodeError: Could not find any matching test nodes: /obj/test_none_args, /obj/TestMyFunc_none_args, /obj/testmyfunc_none_args, /obj/TestMyFunc/none_args, /obj/testmyfunc/none_args, /obj/TestMyFunc, /obj/testmyfunc
 
 
-obj_test_node
--------------
+Basic Context Fixtures
+^^^^^^^^^^^^^^^^^^^^^^
 
-The ``obj_test_node`` fixture will attempt to find a test node under **/obj** (as detailed above in examples).
+\*_test_node
+''''''''''''
+
+The ``*_test_node`` fixtures will attempt to find a test node under their specific contexts (as detailed above for **obj_test_node**)
+
+The following contexts are currently provided:
+    - /obj (obj_test_node)
+    - /out (out_test_node)
+
+
+Object Specific Fixtures
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 obj_test_geo
-------------
+''''''''''''
 
 The ``obj_test_geo`` fixture will attempt to return the geometry of the display node of the found Object test node.
 
-If the found test node (using ``obj_test_node``) does not contain **SOP** nodes a ``RuntimeError`` is raised.
+If the found test node (using ``obj_test_node``) does not contain **SOP** nodes a ``TestNodeDoesNotContainSOPsError`` is raised.
 
 The returned ``hou.Geometry`` object is **read only**.
 
@@ -74,9 +130,8 @@ The returned ``hou.Geometry`` object is **read only**.
         assert obj_test_geo.isReadOnly()
 
 
-
 obj_test_geo_copy
------------------
+'''''''''''''''''
 
 The ``obj_test_geo_copy`` fixture is the same as ``obj_test_geo`` however the found geometry is copied/merged into a
 new ``hou.Geometry`` instance and is not **read only**.

--- a/docs/fixtures/shelf_tools.rst
+++ b/docs/fixtures/shelf_tools.rst
@@ -15,6 +15,8 @@ that would be passed to the shelf tool by Houdini.
 
 In order for this fixture to work, the shelf tool must already be loaded in the Houdini session.
 
+If a tool of the name cannot be found, a ``MissingToolError`` is raised.
+
 Consider the following simple tool definition where the execution sets a value in the kwargs dict:
 
 .. code-block:: xml

--- a/docs/fixtures/ui.rst
+++ b/docs/fixtures/ui.rst
@@ -70,10 +70,11 @@ The temporary ``hou.ui`` object is removed after the test is completed.
 set_ui_available
 ----------------
 
-The ``set_ui_available`` fixtures forces the ``hou.isUIAvailable()`` function to return True.
+The ``set_ui_available`` fixture forces the ``hou.isUIAvailable()`` function to return True. It does **NOT**
+handle any mocking of *hou.ui*, however.
 
 .. code-block:: python
 
-    def test_ui_available(set_ui_available):
+    @pytest.mark.usefixtures("set_ui_available")
+    def test_ui_available():
         assert hou.isUIAvailable()
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
-sphinx-rtd-theme==1.3.0
-sphinx-copybutton==0.5.2
+sphinx
+sphinx-copybutton
+sphinx-rtd-theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
     requires = ["setuptools>=42", "setuptools_scm[toml]>=6.2", "wheel"]
     build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+    # Disable sugar as it interferes with pytester output parsing.
+    addopts = "-p no:sugar --cov --cov-report=html --cov-report=xml --color=yes"
+
 [tool.coverage]
 
     [tool.coverage.run]
@@ -10,11 +14,10 @@
             "pytest_houdini",
         ]
         omit = [
-            "*tests*",
             "*/plugin.py",
+            "*/fixtures/exceptions.py"
         ]
         disable_warnings = [
-            "module-not-imported",
             "module-not-measured",
         ]
     [tool.coverage.report]
@@ -64,6 +67,56 @@
         module = "hou.*"
         ignore_missing_imports = true
 
-[tool.pytest.ini_options]
-    # Disable sugar as it interferes with pytester output parsing.
-    addopts = "-p no:sugar --cov --cov-report=html --cov-report=xml --color=yes"
+[tool.ruff]
+    line-length = 120
+
+    [tool.ruff.lint]
+        extend-select = [
+            "E",  # pycodestyle
+            "W",  # pycodestyle
+            "UP", # pyupgrade
+            "D",  # pydocstyle
+            "F",  # Pyflakes
+            "PL",  # Pylint
+            "RSE",  # flake8-raise
+            "B",  # flake8-bugbear
+            "PT",  #  flake8-pytest-style
+            "C90",  #  mccabe
+            "TRY",  #  tryceratops
+            "FLY",  #  flynt
+            "PERF",  #  Perflint
+            "LOG",  #  flake8-logging
+            "BLE",  # flake8-blind-except
+            "A",  # flake8-builtins
+            "C4",  # flake8-comprehensions
+            "RET",  # flake8-return
+            "SIM",  # flake8-simplify
+            "TCH",  # flake8-type-checking
+            "PTH",  # flake8-use-pathlib
+            "RUF",  # Ruff specific
+            "FBT",  # flake8-boolean-trap
+        ]
+        ignore = [
+            "D104",  # Missing docstring in public module
+            "D105",  # Missing docstring in magic method
+            "D107",  # Missing docstring in __init__
+            "PT004",  # Fixtures not returning anything not starting with _
+        ]
+
+    [tool.ruff.lint.per-file-ignores]
+        "plugin.py" = [
+            "F401",  # Module level import not at top of file
+        ]
+        "tests/*.py" = [
+            "PLR2004",  # Magic value in comparison
+            "PLR6301",  # 'no-self-use' for tests
+        ]
+
+    [tool.ruff.lint.flake8-pytest-style]
+        fixture-parentheses = false  # Match actual pytest recommendation with no parentheses
+
+    [tool.ruff.lint.pydocstyle]
+        convention = "google"
+
+    [tool.ruff.lint.pylint]
+        max-args = 6

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ DESCRIPTION = "pytest plugin for testing code in Houdini."
 URL = "https://github.com/captainhammy/pytest-houdini"
 AUTHOR = "Graham Thompson"
 AUTHOR_EMAIL = "captainhammy@gmail.com"
-REQUIRES_PYTHON = ">=3.7.0"
+REQUIRES_PYTHON = ">=3.9.0"
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
@@ -30,13 +30,13 @@ setup(
     packages=find_packages(where="src", exclude=("tests",)),
     install_requires=[
         "pytest",
+        "pytest-datadir",
+        "pytest-mock",
     ],
     extras_require={
         "test": [
-            "pytest",
+            "coverage",
             "pytest-cov",
-            "pytest-datadir",
-            "pytest-mock",
             "tox",
         ]
     },
@@ -50,10 +50,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Testing",
     ],
     project_urls={"Documentation": "https://pytest-houdini.readthedocs.io/"},

--- a/src/pytest_houdini/fixtures/exceptions.py
+++ b/src/pytest_houdini/fixtures/exceptions.py
@@ -1,0 +1,60 @@
+"""Exceptions raised by pytest-houdini."""
+
+# Future
+from __future__ import annotations
+
+# Standard Library
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hou
+
+
+# Exceptions
+
+
+class MissingToolError(Exception):
+    """Exception raised when a matching tool cannot be found.
+
+    Args:
+        tool_name: The missing tool name.
+    """
+
+    def __init__(self, tool_name: str) -> None:
+        super().__init__(f"Could not find tool: {tool_name}")
+
+
+class NoModuleTestFileError(Exception):
+    """Exception raised when a module test file cannot be found.
+
+    Args:
+        test_file: The test file stem (no extension.)
+        extensions: The extensions which were checked.
+    """
+
+    def __init__(self, test_file: str, extensions: tuple[str, ...]) -> None:
+        msg = f"Could not find a valid test hip: {test_file}{{{','.join(extensions)}}}"
+
+        super().__init__(msg)
+
+
+class NoTestNodeError(Exception):
+    """Exception raised when no test node could be found.
+
+    Args:
+        searched_paths: The test node paths which were searched.
+    """
+
+    def __init__(self, searched_paths: list[str]) -> None:
+        super().__init__(f"Could not find any matching test nodes: {', '.join(searched_paths)}")
+
+
+class TestNodeDoesNotContainSOPsError(Exception):
+    """Exception raised when a test node does not contain SOP nodes.
+
+    Args:
+        node: The node which does not contain SOP nodes.
+    """
+
+    def __init__(self, node: hou.OpNode) -> None:
+        super().__init__(f"{node.path()} does not contain SOP nodes.")

--- a/src/pytest_houdini/fixtures/other.py
+++ b/src/pytest_houdini/fixtures/other.py
@@ -4,23 +4,17 @@
 from __future__ import annotations
 
 # Standard Library
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 # Third Party
 import pytest
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
 # Fixtures
 
 
-@pytest.fixture()
-def remove_abstract_methods(
-    monkeypatch: pytest.MonkeyPatch,
-) -> Generator[Callable, None, None]:
-    """This fixture can be used to temporarily remove abstract methods from a class
-    for testing purposes.
+@pytest.fixture
+def remove_abstract_methods(monkeypatch: pytest.MonkeyPatch) -> Callable:
+    """Fixture to temporarily remove abstract methods from a class for testing purposes.
 
     Consider the following class definition with an abstract method and a concrete method which
     we want to test. Rather than creating a subclass for testing any non-abstract methods we
@@ -35,16 +29,14 @@ def remove_abstract_methods(
         def get_foo(self):
             return "foo"
 
-
     def test_get_foo(remove_abstract_methods):
         remove_abstract_methods(Foo)
 
         f = Foo()
         assert f.get_foo() == "foo"
-
     """
 
     def _remove_abstract(cls: Any) -> None:
         monkeypatch.setattr(cls, "__abstractmethods__", set())
 
-    yield _remove_abstract
+    return _remove_abstract

--- a/src/pytest_houdini/fixtures/shelf_tools.py
+++ b/src/pytest_houdini/fixtures/shelf_tools.py
@@ -4,38 +4,39 @@
 from __future__ import annotations
 
 # Standard Library
-from typing import TYPE_CHECKING, Callable
+from typing import Callable
 
 # Third Party
 import pytest
 
+# pytest-houdini
+from pytest_houdini.fixtures.exceptions import MissingToolError
+
 # Houdini
 import hou
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
 
 # Fixtures
 
 
 @pytest.fixture
-def exec_shelf_tool_script() -> Generator[Callable, None, None]:
+def exec_shelf_tool_script() -> Callable:
     """Fixture to execute a shelf tool."""
 
     def _exec(tool_name: str, kwargs: dict) -> None:
         """Execute tool code inside a file.
 
-        :param tool_name: The name of the tool to execute.
-        :param kwargs: The global 'kwargs' dict for the tool execution.
-        :return:
+        Args:
+            tool_name: The name of the tool to execute.
+            kwargs: The global 'kwargs' dict for the tool execution.
 
+        Raises:
+            MissingToolError: If a tool of the name cannot be found.
         """
         tool = hou.shelves.tool(tool_name)
 
         if tool is None:
-            raise RuntimeError(f"Could not find tool: {tool_name}")
+            raise MissingToolError(tool_name)
 
-        exec(tool.script(), {"kwargs": kwargs})  # pylint: disable=exec-used
+        exec(tool.script(), {"kwargs": kwargs})
 
-    yield _exec
+    return _exec

--- a/src/pytest_houdini/fixtures/soho.py
+++ b/src/pytest_houdini/fixtures/soho.py
@@ -12,17 +12,13 @@ from typing import TYPE_CHECKING, NamedTuple
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
     from pytest_mock import MockerFixture
 
 # Fixtures
 
 
 @pytest.fixture
-def patch_soho(
-    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
-) -> Generator[NamedTuple, None, None]:
+def patch_soho(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> NamedTuple:
     """Mock importing of mantra/soho related modules.
 
     Available mocked modules are available via their original names from the fixture provided named tuple.
@@ -38,7 +34,6 @@ def patch_soho(
     >>> def test_soho_thing(patch_soho):
     ...     patch_soho.mantra.property.return_value = 3
     ...     # Test code
-
     """
     mock_api = mocker.MagicMock()
     mock_frame = mocker.MagicMock()
@@ -54,10 +49,6 @@ def patch_soho(
     monkeypatch.setitem(sys.modules, "mantra", mock_mantra)
     monkeypatch.setitem(sys.modules, "soho", mock_soho)
 
-    MockSoho = namedtuple(
-        "MockSoho", "IFDapi IFDframe IFDhooks IFDsettings mantra soho"
-    )
+    MockSoho = namedtuple("MockSoho", "IFDapi IFDframe IFDhooks IFDsettings mantra soho")
 
-    yield MockSoho(
-        mock_api, mock_frame, mock_hooks, mock_settings, mock_mantra, mock_soho
-    )
+    return MockSoho(mock_api, mock_frame, mock_hooks, mock_settings, mock_mantra, mock_soho)

--- a/src/pytest_houdini/fixtures/ui.py
+++ b/src/pytest_houdini/fixtures/ui.py
@@ -14,8 +14,6 @@ import pytest
 import hou
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
     from pytest_mock import MockerFixture
 
 
@@ -23,44 +21,36 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def mock_hdefereval(
-    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
-) -> Generator[MockerFixture, None, None]:
+def mock_hdefereval(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> MockerFixture:
     """Mock hdefereval which isn't available when running tests via Hython."""
     mocked_hdefereval = mocker.MagicMock()
 
     monkeypatch.setitem(sys.modules, "hdefereval", mocked_hdefereval)
 
-    yield mocked_hdefereval
+    return mocked_hdefereval
 
 
 @pytest.fixture
-def mock_hou_qt(
-    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
-) -> Generator[MockerFixture, None, None]:
+def mock_hou_qt(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> MockerFixture:
     """Mock the hou.qt module which isn't available when running tests via Hython."""
     mock_qt = mocker.MagicMock()
 
     monkeypatch.setattr(hou, "qt", mock_qt, raising=False)
 
-    yield mock_qt
+    return mock_qt
 
 
 @pytest.fixture
-def mock_hou_ui(
-    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
-) -> Generator[MockerFixture, None, None]:
+def mock_hou_ui(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> MockerFixture:
     """Mock the hou.ui module which isn't available when running tests via Hython."""
     mock_ui = mocker.MagicMock()
 
     monkeypatch.setattr(hou, "ui", mock_ui, raising=False)
 
-    yield mock_ui
+    return mock_ui
 
 
 @pytest.fixture
-def set_ui_available(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+def set_ui_available(monkeypatch: pytest.MonkeyPatch) -> None:
     """Fixture to set hou.isUIAvailable() to return True."""
     monkeypatch.setattr(hou, "isUIAvailable", lambda: True)
-
-    yield

--- a/src/pytest_houdini/plugin.py
+++ b/src/pytest_houdini/plugin.py
@@ -1,21 +1,17 @@
 """Initialize the pytest-houdini plugin."""
-# pylint: disable=unused-import
 
-# Try to import 'hou' to test that Houdini is running.
-try:
-    import hou
-
-except ImportError:
-    pass
+# Standard Library
+from importlib.util import find_spec
 
 # If Houdini is running then we can import our fixtures to expose.
-else:
+if find_spec("hou"):
     from pytest_houdini.fixtures.hip_file import (
         clear_hip_file,
         load_module_test_hip_file,
         set_test_frame,
     )
     from pytest_houdini.fixtures.nodes import (
+        create_temp_node,
         obj_test_geo,
         obj_test_geo_copy,
         obj_test_node,

--- a/src/pytest_houdini/tools.py
+++ b/src/pytest_houdini/tools.py
@@ -41,6 +41,5 @@ def does_not_raise() -> Generator[None, None, None]:
             result = divider(1, value)
 
             assert result == expected
-
     """
     yield

--- a/tests/fixtures/test_hip_file.py
+++ b/tests/fixtures/test_hip_file.py
@@ -23,12 +23,14 @@ pytest_plugins = ["pytester"]
 
 def test_clear_hip_file(pytester):
     """Test the 'clear_hip_file' fixture."""
-
     pytester.makepyfile(
         """
+import pytest
+
 import hou
 
-def test_clear_hip_file(clear_hip_file, request):
+@pytest.mark.usefixtures("clear_hip_file")
+def test_clear_hip_file(request):
     assert hou.node("/obj").children() == ()
 
     obj = hou.node("/obj")
@@ -57,10 +59,9 @@ def test_clear_hip_file(clear_hip_file, request):
     assert hou.node("/obj").children() == ()
 
 
-@pytest.mark.parametrize("ext", (".hip", ".hiplc", ".hipnc", None))
+@pytest.mark.parametrize("ext", [".hip", ".hiplc", ".hipnc", None])
 def test_load_module_test_hip_file(pytester, ext, shared_datadir):
     """Test the 'load_module_test_hip_file' fixture."""
-
     data_dir = pytester.mkdir("data")
 
     expected_path = "untitled.hip"
@@ -98,7 +99,6 @@ def test_load_module_test_hip_file():
 
 def test_set_test_frame(pytester):
     """Test the 'set_test_frame' fixture."""
-
     pytester.makepyfile(
         """
 import hou

--- a/tests/fixtures/test_other.py
+++ b/tests/fixtures/test_other.py
@@ -16,7 +16,6 @@ pytest_plugins = ["pytester"]
 
 def test_remove_abstract_methods(pytester, shared_datadir):
     """Test the 'remove_abstract_methods' fixture."""
-
     pytester.makepyfile(
         """
 import abc

--- a/tests/fixtures/test_shelf_tools.py
+++ b/tests/fixtures/test_shelf_tools.py
@@ -22,6 +22,7 @@ def test_exec_shelf_tool_script(pytester, shared_datadir):
         f"""
 import pytest
 
+from pytest_houdini.fixtures.exceptions import MissingToolError
 from pytest_houdini.tools import does_not_raise
 
 import hou
@@ -29,7 +30,7 @@ import hou
 @pytest.mark.parametrize(
     "tool_name, raiser",
     (
-        ("_not_a_tool_", pytest.raises(RuntimeError)),
+        ("_not_a_tool_", pytest.raises(MissingToolError)),
         ("pytest_houdini_test_tool", does_not_raise()),
     )
 )

--- a/tests/fixtures/test_ui.py
+++ b/tests/fixtures/test_ui.py
@@ -16,7 +16,6 @@ pytest_plugins = ["pytester"]
 
 def test_mock_hdefereval(pytester):
     """Test the 'mock_hdefereval' fixture."""
-
     pytester.makepyfile(
         """
 import hou
@@ -35,46 +34,66 @@ def test_mock_hdefereval(mock_hdefereval):
 
 def test_mock_hou_qt(pytester):
     """Test the 'mock_hou_qt' fixture."""
-
     pytester.makepyfile(
         """
 import hou
+
+# Ensure hou.qt does not exist before any manipulation of it.
+def test_no_orig_qt():
+    assert not hasattr(hou, "qt")
+
 
 def test_mock_hou_qt(mock_hou_qt):
     assert hou.qt == mock_hou_qt
 
+
+# Ensure hou.qt does not exist after any manipulation of it.
+def test_no_post_qt():
+    assert not hasattr(hou, "qt")
+
 """
     )
     result = pytester.runpytest()
 
-    result.assert_outcomes(passed=1)
+    result.assert_outcomes(passed=3)
 
 
 def test_mock_hou_ui(pytester):
     """Test the 'mock_hou_ui' fixture."""
-
     pytester.makepyfile(
         """
 import hou
 
+# Ensure hou.ui does not exist before any manipulation of it.
+def test_no_orig_ui():
+    assert not hasattr(hou, "ui")
+
+
 def test_mock_hou_ui(mock_hou_ui):
     assert hou.ui == mock_hou_ui
+
+
+# Ensure hou.ui does not exist after any manipulation of it.
+def test_no_post_ui():
+    assert not hasattr(hou, "ui")
 
 """
     )
     result = pytester.runpytest()
 
-    result.assert_outcomes(passed=1)
+    result.assert_outcomes(passed=3)
 
 
 def test_set_ui_available(pytester):
     """Test the 'set_ui_available' fixture."""
-
     pytester.makepyfile(
         """
+import pytest
+
 import hou
 
-def test_set_ui_available(set_ui_available):
+@pytest.mark.usefixtures("set_ui_available")
+def test_set_ui_available():
     assert hou.isUIAvailable()
 
 """

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,7 +7,7 @@ import pytest_houdini.tools
 
 
 def test_does_not_raise():
-    """Test pytest_houdini.tools.does_not_raise()
+    """Test pytest_houdini.tools.does_not_raise().
 
     This test is pretty useless and mostly just here for test coverage.
     """

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,20 @@
 [tox]
-envlist = h195,h20,black-check,flake8,isort-check,mypy
+envlist = h20,ruff-check,ruff-format-check,isort-check,mypy,docstring-check
 skipsdist = true
 
 [gh-actions]
 python =
-    3.9: py39, black-check, flake8, isort-check, mypy, pylint, mypy
-    3.10: py310, black-check, flake8, isort-check, mypy, pylint, mypy
-
-[pytest]
-pythonpath = src
-addopts = --cov --cov-report=html --cov-report=xml --color=yes
-
-[flake8]
-exclude =
-    venv
-    .tox
-    build
-    docs
-    .github
-max-line-length = 120
-extend-ignore =
-    # flake8 and black differ with opinions of whitespace around ':'
-    E203
-per-file-ignores =
-    src/pytest_houdini/plugin.py:F401,F403
-    tests/*:E501
+    3.9: py39, ruff-check, ruff-format-check, isort-check, mypy, docstring-check
+    3.10: py310, ruff-check, ruff-format-check, isort-check, mypy, docstring-check
 
 [testenv]
 allowlist_externals=
+    coverage
     echo
     env
     hython
-deps = .[test]
+deps =
+    .[test]
 setenv =
     # Extra args to pass to the Hython command.  This is really only useful for local testing using
     # my (Graham's) setup which relies on selecting the Houdini version via wrapper arg. When things
@@ -43,7 +26,6 @@ commands =
     # We need to force in the tox env as we won't be using the created venv and thus won't get the
     # packages added to the path.
     env PYTHONPATH={envsitepackagesdir} hython {env:hython_extra} -m pytest tests/
-    echo "View test coverage report at file://{toxinidir}/coverage_html_report/index.html"
     coverage report --fail-under=100 --skip-covered
 
 [testenv:h195]
@@ -56,17 +38,17 @@ basepython=py310
 setenv =
   hython_extra=--version 20.0
 
-[testenv:black-check]
-deps = black
-commands = black --check src/ tests/ setup.py
+[testenv:ruff-check]
+deps = ruff
+commands = ruff check --preview src/ tests/
 
-[testenv:black-run]
-deps = black
-commands = black src/ tests/ setup.py
+[testenv:ruff-format-check]
+deps = ruff
+commands = ruff format --preview --check src/ tests/
 
-[testenv:flake8]
-deps = flake8
-commands = flake8
+[testenv:ruff-format-run]
+deps = ruff
+commands = ruff format --preview src/ tests/
 
 [testenv:isort-check]
 deps = isort
@@ -81,3 +63,20 @@ deps =
     .[test]
     mypy
 commands = mypy
+
+[testenv:docstring-check]
+deps =
+    pydocstringformatter
+commands = pydocstringformatter --exit-code src/
+
+[testenv:docstring-run]
+deps =
+    pydocstringformatter
+commands = pydocstringformatter --write src/
+
+[testenv:docs]
+deps =
+    -r docs/requirements.txt
+commands =
+    sphinx-build -b html -d {envtmpdir}/doctrees docs/ {envtmpdir}/html
+    echo "Docs available at file://{envtmpdir}/html/index.html"


### PR DESCRIPTION
A large number of ruff tests are enabled and result in various code quality improvements.

This also adds a new `create_temp_node` fixture.

fixes: #15, #16