### PR TITLE
chore: use a better way of specifying code coverage secret value

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,5 +42,5 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,5 @@ build
 dist
 *egg-info*
 
-tests/fixtures/data/backup
+**/backup/*.hip*
 


### PR DESCRIPTION
chore: use a more robust way of excluding backup hip files