### PR TITLE
feat: add new context manager to return an appropriate parent node for node creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@
             "D105",  # Missing docstring in magic method
             "D107",  # Missing docstring in __init__
             "PT004",  # Fixtures not returning anything not starting with _
+            "PT006",  # Allow string parameter names
         ]
 
     [tool.ruff.lint.per-file-ignores]

--- a/src/pytest_houdini/exceptions.py
+++ b/src/pytest_houdini/exceptions.py
@@ -1,0 +1,24 @@
+"""Exceptions raised by pytest-houdini."""
+
+# Future
+from __future__ import annotations
+
+# Standard Library
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hou
+
+
+# Exceptions
+
+
+class UnsupportedCategoryError(ValueError):
+    """Exception raised when an invalid node type category is passed.
+
+    Args:
+        category: The invalid node type category.
+    """
+
+    def __init__(self, category: hou.NodeTypeCategory) -> None:
+        super().__init__(f"Unknown category type {category.name()}")

--- a/src/pytest_houdini/fixtures/exceptions.py
+++ b/src/pytest_houdini/fixtures/exceptions.py
@@ -1,4 +1,4 @@
-"""Exceptions raised by pytest-houdini."""
+"""Exceptions raised by pytest-houdini fixtures."""
 
 # Future
 from __future__ import annotations

--- a/src/pytest_houdini/tools.py
+++ b/src/pytest_houdini/tools.py
@@ -60,6 +60,9 @@ def context_container(category: hou.NodeTypeCategory) -> Generator[hou.OpNode, N
     # of a matching context.
     else:
         if category_name == "Cop2":
+            container = hou.node("/img").createNode("img")
+
+        elif category_name == "Cop":
             container = hou.node("/img").createNode("copnet")
 
         elif category_name == "Sop":

--- a/src/pytest_houdini/tools.py
+++ b/src/pytest_houdini/tools.py
@@ -62,8 +62,9 @@ def context_container(category: hou.NodeTypeCategory) -> Generator[hou.OpNode, N
         if category_name == "Cop2":
             container = hou.node("/img").createNode("img")
 
-        elif category_name == "Cop":
-            container = hou.node("/img").createNode("copnet")
+        # Enable this once 20.5 is out.
+        # elif category_name == "Cop":
+        #     container = hou.node("/img").createNode("copnet")
 
         elif category_name == "Sop":
             container = hou.node("/obj").createNode("geo")

--- a/tests/fixtures/test_shelf_tools.py
+++ b/tests/fixtures/test_shelf_tools.py
@@ -19,10 +19,11 @@ def test_exec_shelf_tool_script(pytester, shared_datadir):
     shelf_test_file = shared_datadir / "test_shelf_files.shelf"
 
     pytester.makepyfile(f"""
+from contextlib import nullcontext
+
 import pytest
 
 from pytest_houdini.fixtures.exceptions import MissingToolError
-from pytest_houdini.tools import does_not_raise
 
 import hou
 
@@ -30,7 +31,7 @@ import hou
     "tool_name, raiser",
     (
         ("_not_a_tool_", pytest.raises(MissingToolError)),
-        ("pytest_houdini_test_tool", does_not_raise()),
+        ("pytest_houdini_test_tool", nullcontext()),
     )
 )
 def test_exec_shelf_tool_script(exec_shelf_tool_script, tool_name, raiser):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -24,7 +24,7 @@ import hou
         (hou.lopNodeTypeCategory(), nullcontext(), hou.node("/stage")),
         (hou.shopNodeTypeCategory(), nullcontext(), hou.node("/shop")),
         (hou.cop2NodeTypeCategory(), nullcontext(), hou.nodeType("CopNet/img")),
-        (hou.nodeTypeCategories().get("Cop"), nullcontext(), hou.nodeType("CopNet/copnet")),
+        # (hou.copNodeTypeCategory(), nullcontext(), hou.nodeType("CopNet/copnet")),
         (hou.sopNodeTypeCategory(), nullcontext(), hou.nodeType("Object/geo")),
         (hou.dopNodeTypeCategory(), nullcontext(), hou.nodeType("Object/dopnet")),
         (hou.topNodeTypeCategory(), nullcontext(), hou.nodeType("Object/topnet")),

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,17 +1,52 @@
 """Test the pytest_houdini.tools module."""
 
+# Standard Library
+from contextlib import nullcontext
+
+# Third Party
+import pytest
+
 # pytest-houdini
 import pytest_houdini.tools
+from pytest_houdini.exceptions import UnsupportedCategoryError
+
+# Houdini
+import hou
 
 # Tests
 
 
-def test_does_not_raise():
-    """Test pytest_houdini.tools.does_not_raise().
+@pytest.mark.parametrize(
+    "category, raiser, expected",
+    [
+        (hou.objNodeTypeCategory(), nullcontext(), hou.node("/obj")),
+        (hou.ropNodeTypeCategory(), nullcontext(), hou.node("/out")),
+        (hou.lopNodeTypeCategory(), nullcontext(), hou.node("/stage")),
+        (hou.shopNodeTypeCategory(), nullcontext(), hou.node("/shop")),
+        (hou.cop2NodeTypeCategory(), nullcontext(), hou.nodeType("CopNet/copnet")),
+        (hou.sopNodeTypeCategory(), nullcontext(), hou.nodeType("Object/geo")),
+        (hou.dopNodeTypeCategory(), nullcontext(), hou.nodeType("Object/dopnet")),
+        (hou.topNodeTypeCategory(), nullcontext(), hou.nodeType("Object/topnet")),
+        (hou.managerNodeTypeCategory(), pytest.raises(UnsupportedCategoryError), None),
+    ],
+)
+def test_context_container(category, raiser, expected):
+    """Test pytest_houdini.tools.context_container()."""
+    # Keep track if the container is expected to be deleted based on whether
+    # the expected object is a node type (specific temporary container)
+    expect_delete = isinstance(expected, hou.NodeType)
 
-    This test is pretty useless and mostly just here for test coverage.
-    """
-    with pytest_houdini.tools.does_not_raise():
-        x = 1
+    with raiser, pytest_houdini.tools.context_container(category) as container:
+        if isinstance(expected, hou.Node):
+            assert container == expected
 
-    assert x == 1
+        else:
+            assert container.type() == expected
+
+    if expected is not None:
+        # If the container was expected to be deleted, trying to access it will result in
+        # a hou.ObjectWasDeleted exception so use that to confirm it was deleted.
+        persistence_raiser = pytest.raises(hou.ObjectWasDeleted) if expect_delete else nullcontext()
+
+        with persistence_raiser:
+            container.path()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -23,7 +23,8 @@ import hou
         (hou.ropNodeTypeCategory(), nullcontext(), hou.node("/out")),
         (hou.lopNodeTypeCategory(), nullcontext(), hou.node("/stage")),
         (hou.shopNodeTypeCategory(), nullcontext(), hou.node("/shop")),
-        (hou.cop2NodeTypeCategory(), nullcontext(), hou.nodeType("CopNet/copnet")),
+        (hou.cop2NodeTypeCategory(), nullcontext(), hou.nodeType("CopNet/img")),
+        (hou.nodeTypeCategories().get("Cop"), nullcontext(), hou.nodeType("CopNet/copnet")),
         (hou.sopNodeTypeCategory(), nullcontext(), hou.nodeType("Object/geo")),
         (hou.dopNodeTypeCategory(), nullcontext(), hou.nodeType("Object/dopnet")),
         (hou.topNodeTypeCategory(), nullcontext(), hou.nodeType("Object/topnet")),
@@ -32,6 +33,9 @@ import hou
 )
 def test_context_container(category, raiser, expected):
     """Test pytest_houdini.tools.context_container()."""
+    if category is None:
+        return
+
     # Keep track if the container is expected to be deleted based on whether
     # the expected object is a node type (specific temporary container)
     expect_delete = isinstance(expected, hou.NodeType)


### PR DESCRIPTION
Remove does_not_raise() context manager tool.

Fixes: #32, #33